### PR TITLE
Background image on tile

### DIFF
--- a/AdaptiveTileExtensions/Alignment.cs
+++ b/AdaptiveTileExtensions/Alignment.cs
@@ -4,6 +4,7 @@
     {
         Left,
         Center,
-        Right
+        Right,
+        Stretch
     }
 }

--- a/AdaptiveTileExtensions/Branding.cs
+++ b/AdaptiveTileExtensions/Branding.cs
@@ -4,6 +4,7 @@ namespace AdaptiveTileExtensions
     {
         Name,
         None,
+        Logo,
         NameAndLogo
     }
 }

--- a/AdaptiveTileExtensions/TileBinding.cs
+++ b/AdaptiveTileExtensions/TileBinding.cs
@@ -11,6 +11,7 @@ namespace AdaptiveTileExtensions
 
         internal TileBinding()
         {
+            
         }
 
         public static TileBinding Create(TemplateType templateType)
@@ -18,6 +19,9 @@ namespace AdaptiveTileExtensions
             return new TileBinding { TemplateType = templateType };
         }
 
+
+        public TileImage BackgroundImage { get; set; }
+         
         public TemplateType TemplateType { get; set; }
 
         public Branding? Branding { get; set; }
@@ -99,6 +103,12 @@ namespace AdaptiveTileExtensions
             }
 
             sb.Append(">");
+
+            if (!string.IsNullOrEmpty(BackgroundImage?.Source))
+            {
+                sb.Append(BackgroundImage.GetXml());
+            }
+
             foreach (var item in _items)
             {
                 sb.Append(item.GetXml());

--- a/AdaptiveTileExtensionsSample/MainPage.xaml.cs
+++ b/AdaptiveTileExtensionsSample/MainPage.xaml.cs
@@ -22,27 +22,61 @@ namespace AdaptiveTileExtensionsSample
         private void OnLoaded(object sender, RoutedEventArgs routedEventArgs)
         {
             var tile = AdaptiveTile.CreateTile();
-            var binding = TileBinding.Create(TemplateType.TileWide);
+            
+            #region for wide tile with background 
+            
+            var wideBinding = TileBinding.Create(TemplateType.TileWide);
+            wideBinding.Branding = Branding.NameAndLogo;
+            var wideLogo = new TileImage(ImagePlacement.Background)
+            {
+                Source = "http://fc02.deviantart.net/fs71/i/2013/359/a/4/deadpool_logo_1_fill_by_mr_droy-d5q6y5u.png"
+            };
+            //background/peek images need to be at the root of the binding;
+            wideBinding.BackgroundImage = wideLogo;
+
+            var wideHeader = new Text("You have mail") {Style = TextStyle.Body};
+            var wideContent = new Text("Someone likes you!") {Style = TextStyle.Caption};
+
+            var wideSubgroup = new SubGroup();
+            wideSubgroup.AddText(wideHeader);
+            wideSubgroup.AddText(wideContent);
+            
+            wideBinding.AddSubgroup(wideSubgroup, true);
+
+            #endregion
+
+            #region square tile 
+           
+            var binding = TileBinding.Create(TemplateType.TileMedium);
             binding.Branding = Branding.None;
 
-            var header = new Text("You have mail") {Style = TextStyle.Body};
-            var content = new Text("Someone likes you!") {Style = TextStyle.Caption};
+            var header = new Text("You have mail") { Style = TextStyle.Body, WrapText = true };
+            var content = new Text("Someone likes you!") { Style = TextStyle.Caption, IsSubtleStyle = true , WrapText = true,Alignment = Alignment.Center};
             var logo = new TileImage(ImagePlacement.Inline)
             {
                 Source = "http://fc02.deviantart.net/fs71/i/2013/359/a/4/deadpool_logo_1_fill_by_mr_droy-d5q6y5u.png"
             };
 
-            var logoSubGroup = new SubGroup {Width = 40};
-            logoSubGroup.AddImage(logo);
+            var imageSubgroup = new SubGroup()
+            {
+                Width = 20
+            };
+            imageSubgroup.AddImage(logo);
+
 
             var subgroup = new SubGroup();
             subgroup.AddText(header);
             subgroup.AddText(content);
+          
+            binding.AddSubgroup(imageSubgroup);
+            binding.AddSubgroup(subgroup);
+            
+            #endregion
 
-            binding.AddSubgroup(logoSubGroup);
-            binding.AddSubgroup(subgroup, true);
+            // Add the types of tile bindings to the tile.
+            tile.Tiles.Add(wideBinding);
+            tile.Tiles.Add(binding); 
 
-            tile.Tiles.Add(binding);
             var notification = tile.GetNotification();
 
             TileUpdateManager.CreateTileUpdaterForApplication().Update(notification);

--- a/AdaptiveTileExtensionsSample/Package.appxmanifest
+++ b/AdaptiveTileExtensionsSample/Package.appxmanifest
@@ -38,6 +38,7 @@
         Description="AdaptiveTileExtensionsSample"
         BackgroundColor="#464646">
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide.png"/>
       </uap:VisualElements>
     </Application>
   </Applications>


### PR DESCRIPTION
_Sorry, wasn't planning this to be more than one change, was just trying to get the background image working._

Nice and useful library :)  Needed to fix the background image and then did a couple of bits 
- Manifest has wide tile added
- Two title sizes have been added to demo using the two different sizes.
- The background image needs to added as the first element to the binding, so I have added it to the object to be added that way. Now, I dunno if this is the best way of doing it, but it works.
- Tweaked the demo square option as it was the new subgroup was forcing the tile to only show the image.
- I have also added a couple more items to the alignment and branding enums as they are options in the http://blogs.msdn.com/b/tiles_and_toasts/archive/2015/06/30/adaptive-tile-templates-schema-and-documentation.aspx and I was looking at them when trying to stop the image dominating the tile.
